### PR TITLE
Add LangGraph SQL agent project

### DIFF
--- a/langgraph-sql-agent/README.md
+++ b/langgraph-sql-agent/README.md
@@ -1,0 +1,21 @@
+# LangGraph SQL Agent
+
+This project provides a modular agent-based system built with [LangGraph](https://github.com/...), using a vector database and MySQL backend to answer natural language questions with structured data.
+
+## Setup
+
+1. Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Configure credentials in `config/config.yaml`.
+
+3. Run the main script:
+
+```bash
+python main.py --query "Your question here"
+```
+
+See `config/config.yaml` for configuration options.

--- a/langgraph-sql-agent/agent/__init__.py
+++ b/langgraph-sql-agent/agent/__init__.py
@@ -1,0 +1,3 @@
+from .graph import build_graph
+
+__all__ = ["build_graph"]

--- a/langgraph-sql-agent/agent/graph.py
+++ b/langgraph-sql-agent/agent/graph.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from langgraph.graph import StateGraph, END
+from langgraph.checkpoint.sqlite import SqliteSaver
+from langchain.llms import OpenAI
+from langchain.embeddings import OpenAIEmbeddings
+
+from typing import Dict
+
+from config.config import load_config
+from vector.qdrant_client import QdrantVectorClient
+from db.mysql_connector import create_mysql_engine
+
+from .nodes.user_query import user_query_node
+from .nodes.retriever import retrieval_node
+from .nodes.sql_builder import sql_builder_node
+from .nodes.sql_validator import sql_validator_node
+from .nodes.sql_executor import sql_executor_node
+from .nodes.output import output_node
+
+
+class AgentState(Dict):
+    query: str
+    context: str
+    sql: str
+    valid: bool
+    results: list
+    error: str
+
+
+def build_graph(config: dict | None = None, debug: bool = False):
+    if config is None:
+        config = load_config()
+
+    # Initialize external dependencies
+    vector_config = config.get("vector", {})
+    vector_client = QdrantVectorClient(url=vector_config["url"], collection=vector_config["collection"])
+
+    llm = OpenAI(api_key=config["embeddings"].get("api_key"))
+    engine = create_mysql_engine(config["sql"]["connection_string"])
+
+    # Build graph
+    sg = StateGraph(AgentState)
+    sg.add_node("user_query", lambda state: user_query_node(state))
+    sg.add_node("retrieval", lambda state: retrieval_node(state, vector_client))
+    sg.add_node("build_sql", lambda state: sql_builder_node(state, llm))
+    sg.add_node("validate", lambda state: sql_validator_node(state, engine))
+    sg.add_node("execute", lambda state: sql_executor_node(state, engine))
+    sg.add_node("output", lambda state: output_node(state, debug=debug))
+
+    # Edges
+    sg.set_entry_point("user_query")
+    sg.add_edge("user_query", "retrieval")
+    sg.add_edge("retrieval", "build_sql")
+    sg.add_edge("build_sql", "validate")
+    sg.add_conditional_edges(
+        "validate",
+        lambda state: "execute" if state.get("valid") else "output",
+    )
+    sg.add_edge("execute", "output")
+    sg.add_edge("output", END)
+
+    memory = SqliteSaver(".langgraph.db")
+    graph = sg.compile(checkpointer=memory)
+    return graph

--- a/langgraph-sql-agent/agent/nodes/output.py
+++ b/langgraph-sql-agent/agent/nodes/output.py
@@ -1,0 +1,8 @@
+from typing import Dict
+
+
+def output_node(state: Dict, debug: bool = False) -> Dict:
+    if not debug:
+        return {"answer": state.get("results")}
+    else:
+        return state

--- a/langgraph-sql-agent/agent/nodes/retriever.py
+++ b/langgraph-sql-agent/agent/nodes/retriever.py
@@ -1,0 +1,9 @@
+from typing import Dict
+from vector.base import VectorClient
+
+
+def retrieval_node(state: Dict, vector_client: VectorClient, k: int = 5) -> Dict:
+    query = state.get("query")
+    docs = vector_client.similarity_search(query, k=k)
+    state["context"] = "\n".join(docs)
+    return state

--- a/langgraph-sql-agent/agent/nodes/sql_builder.py
+++ b/langgraph-sql-agent/agent/nodes/sql_builder.py
@@ -1,0 +1,18 @@
+from typing import Dict
+from langchain.prompts import ChatPromptTemplate
+from langchain.llms import OpenAI
+
+
+SQL_PROMPT = ChatPromptTemplate.from_template(
+    """You are a helpful assistant that writes SQL queries.\n"""
+    "Context:\n{context}\n"  # inserted from retrieval
+    "User question: {question}\n"  # query
+    "Write a SQL query."
+)
+
+
+def sql_builder_node(state: Dict, llm: OpenAI) -> Dict:
+    prompt = SQL_PROMPT.format(context=state.get("context", ""), question=state.get("query"))
+    sql = llm(prompt).strip()
+    state["sql"] = sql
+    return state

--- a/langgraph-sql-agent/agent/nodes/sql_executor.py
+++ b/langgraph-sql-agent/agent/nodes/sql_executor.py
@@ -1,0 +1,10 @@
+from typing import Dict
+from db.mysql_connector import execute_sql
+
+
+def sql_executor_node(state: Dict, engine) -> Dict:
+    if not state.get("valid", False):
+        return state
+    rows = execute_sql(engine, state["sql"])
+    state["results"] = [dict(row) for row in rows]
+    return state

--- a/langgraph-sql-agent/agent/nodes/sql_validator.py
+++ b/langgraph-sql-agent/agent/nodes/sql_validator.py
@@ -1,0 +1,15 @@
+from typing import Dict
+from sqlalchemy.exc import SQLAlchemyError
+from db.mysql_connector import reflect_schema
+
+
+def sql_validator_node(state: Dict, engine) -> Dict:
+    try:
+        # simple validation by running EXPLAIN
+        with engine.connect() as conn:
+            conn.execute(f"EXPLAIN {state['sql']}")
+        state["valid"] = True
+    except SQLAlchemyError as e:
+        state["valid"] = False
+        state["error"] = str(e)
+    return state

--- a/langgraph-sql-agent/agent/nodes/user_query.py
+++ b/langgraph-sql-agent/agent/nodes/user_query.py
@@ -1,0 +1,7 @@
+from typing import Dict
+
+
+def user_query_node(state: Dict) -> Dict:
+    """Pass the user query through the state."""
+    # The query is already provided in the state when invoking the graph.
+    return state

--- a/langgraph-sql-agent/config/__init__.py
+++ b/langgraph-sql-agent/config/__init__.py
@@ -1,0 +1,3 @@
+from .config import load_config
+
+__all__ = ["load_config"]

--- a/langgraph-sql-agent/config/config.py
+++ b/langgraph-sql-agent/config/config.py
@@ -1,0 +1,9 @@
+import yaml
+from pathlib import Path
+
+CONFIG_PATH = Path(__file__).resolve().parent / "config.yaml"
+
+
+def load_config(path: Path = CONFIG_PATH) -> dict:
+    with open(path, "r") as f:
+        return yaml.safe_load(f)

--- a/langgraph-sql-agent/config/config.yaml
+++ b/langgraph-sql-agent/config/config.yaml
@@ -1,0 +1,13 @@
+vector:
+  type: qdrant
+  url: "http://localhost:6333"
+  collection: "documents"
+
+sql:
+  connection_string: "mysql+pymysql://user:password@localhost:3306/mydb"
+
+embeddings:
+  model: openai
+  api_key: "YOUR_OPENAI_KEY"
+
+

--- a/langgraph-sql-agent/db/__init__.py
+++ b/langgraph-sql-agent/db/__init__.py
@@ -1,0 +1,3 @@
+from .mysql_connector import create_mysql_engine, reflect_schema, execute_sql
+
+__all__ = ["create_mysql_engine", "reflect_schema", "execute_sql"]

--- a/langgraph-sql-agent/db/mysql_connector.py
+++ b/langgraph-sql-agent/db/mysql_connector.py
@@ -1,0 +1,19 @@
+from sqlalchemy import create_engine, text, MetaData
+from sqlalchemy.engine import Engine
+from typing import Any, List
+
+
+def create_mysql_engine(connection_string: str) -> Engine:
+    return create_engine(connection_string)
+
+
+def reflect_schema(engine: Engine) -> MetaData:
+    meta = MetaData()
+    meta.reflect(bind=engine)
+    return meta
+
+
+def execute_sql(engine: Engine, sql: str) -> List[Any]:
+    with engine.connect() as conn:
+        result = conn.execute(text(sql))
+        return result.fetchall()

--- a/langgraph-sql-agent/main.py
+++ b/langgraph-sql-agent/main.py
@@ -1,0 +1,19 @@
+import argparse
+from agent.graph import build_graph
+from config.config import load_config
+
+
+def main():
+    parser = argparse.ArgumentParser(description="LangGraph SQL Agent")
+    parser.add_argument("--query", required=True, help="Natural language question")
+    parser.add_argument("--debug", action="store_true", help="Return intermediate steps")
+    args = parser.parse_args()
+
+    config = load_config()
+    graph = build_graph(config, debug=args.debug)
+    result = graph.invoke({"query": args.query})
+    print(result)
+
+
+if __name__ == "__main__":
+    main()

--- a/langgraph-sql-agent/requirements.txt
+++ b/langgraph-sql-agent/requirements.txt
@@ -1,0 +1,6 @@
+langchain>=0.1.0
+langgraph>=0.0.4
+qdrant-client>=1.6.0
+SQLAlchemy>=2.0
+PyMySQL>=1.0
+PyYAML>=6.0

--- a/langgraph-sql-agent/vector/__init__.py
+++ b/langgraph-sql-agent/vector/__init__.py
@@ -1,0 +1,4 @@
+from .qdrant_client import QdrantVectorClient
+from .base import VectorClient
+
+__all__ = ["QdrantVectorClient", "VectorClient"]

--- a/langgraph-sql-agent/vector/base.py
+++ b/langgraph-sql-agent/vector/base.py
@@ -1,0 +1,11 @@
+from abc import ABC, abstractmethod
+from typing import List
+
+
+class VectorClient(ABC):
+    """Abstract base class for vector database clients."""
+
+    @abstractmethod
+    def similarity_search(self, query: str, k: int = 5) -> List[str]:
+        """Return a list of documents most similar to the query."""
+        raise NotImplementedError

--- a/langgraph-sql-agent/vector/qdrant_client.py
+++ b/langgraph-sql-agent/vector/qdrant_client.py
@@ -1,0 +1,14 @@
+from typing import List
+from qdrant_client import QdrantClient
+from .base import VectorClient
+
+
+class QdrantVectorClient(VectorClient):
+    def __init__(self, url: str, collection: str):
+        self.client = QdrantClient(url=url)
+        self.collection = collection
+
+    def similarity_search(self, query: str, k: int = 5) -> List[str]:
+        # Here we assume embeddings already exist in Qdrant
+        results = self.client.search(collection_name=self.collection, query_text=query, top=k)
+        return [hit.payload.get("text", "") for hit in results]


### PR DESCRIPTION
## Summary
- add modular LangGraph SQL agent project with Qdrant and MySQL connectors
- implement graph with nodes for query, retrieval, SQL generation, validation, and execution
- provide config files and requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849953beeec83258b6eb4e3046aef51