### PR TITLE
Add modular LangGraph SQL agent with UI

### DIFF
--- a/langgraph-sql-agent/README.md
+++ b/langgraph-sql-agent/README.md
@@ -1,6 +1,6 @@
 # LangGraph SQL Agent
 
-This project provides a modular agent-based system built with [LangGraph](https://github.com/...), using a vector database and MySQL backend to answer natural language questions with structured data.
+This project provides a modular agent-based system built with [LangGraph](https://github.com/langchain-ai/langgraph). It retrieves relevant context from a Qdrant vector database, generates SQL with your preferred LLM, executes the query against MySQL and persists the full conversation history.
 
 ## Setup
 
@@ -16,6 +16,11 @@ pip install -r requirements.txt
 
 ```bash
 python main.py --query "Your question here"
+```
+4. Launch the Streamlit UI:
+
+```bash
+streamlit run ui/app.py
 ```
 
 See `config/config.yaml` for configuration options.

--- a/langgraph-sql-agent/agent/nodes/__init__.py
+++ b/langgraph-sql-agent/agent/nodes/__init__.py
@@ -1,0 +1,17 @@
+from .user_query import user_query_node
+from .retriever import retrieval_node
+from .sql_builder import sql_builder_node
+from .sql_validator import sql_validator_node
+from .sql_executor import sql_executor_node
+from .output import output_node
+from .history import history_node
+
+__all__ = [
+    "user_query_node",
+    "retrieval_node",
+    "sql_builder_node",
+    "sql_validator_node",
+    "sql_executor_node",
+    "output_node",
+    "history_node",
+]

--- a/langgraph-sql-agent/agent/nodes/history.py
+++ b/langgraph-sql-agent/agent/nodes/history.py
@@ -1,0 +1,8 @@
+from typing import Dict
+
+from chat.history_manager import HistoryManager
+
+
+def history_node(state: Dict, manager: HistoryManager, session_id: str) -> Dict:
+    manager.add_message(session_id, "assistant", str(state.get("answer")))
+    return state

--- a/langgraph-sql-agent/agent/nodes/sql_builder.py
+++ b/langgraph-sql-agent/agent/nodes/sql_builder.py
@@ -1,6 +1,6 @@
 from typing import Dict
 from langchain.prompts import ChatPromptTemplate
-from langchain.llms import OpenAI
+from providers.llms.base import LLMProvider
 
 
 SQL_PROMPT = ChatPromptTemplate.from_template(
@@ -11,7 +11,7 @@ SQL_PROMPT = ChatPromptTemplate.from_template(
 )
 
 
-def sql_builder_node(state: Dict, llm: OpenAI) -> Dict:
+def sql_builder_node(state: Dict, llm: LLMProvider) -> Dict:
     prompt = SQL_PROMPT.format(context=state.get("context", ""), question=state.get("query"))
     sql = llm(prompt).strip()
     state["sql"] = sql

--- a/langgraph-sql-agent/chat/__init__.py
+++ b/langgraph-sql-agent/chat/__init__.py
@@ -1,0 +1,3 @@
+from .history_manager import HistoryManager
+
+__all__ = ["HistoryManager"]

--- a/langgraph-sql-agent/chat/db.py
+++ b/langgraph-sql-agent/chat/db.py
@@ -1,0 +1,11 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+
+def get_engine(connection_string: str):
+    return create_engine(connection_string)
+
+
+def get_session_factory(connection_string: str):
+    engine = get_engine(connection_string)
+    return sessionmaker(bind=engine)

--- a/langgraph-sql-agent/chat/history_manager.py
+++ b/langgraph-sql-agent/chat/history_manager.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import uuid
+
+from .models import Base, Message
+from .db import get_engine, get_session_factory
+
+
+class HistoryManager:
+    def __init__(self, db_uri: str):
+        self.db_uri = db_uri
+        self.engine = get_engine(db_uri)
+        Base.metadata.create_all(self.engine)
+        self.session_factory = get_session_factory(db_uri)
+
+    def create_session_id(self) -> str:
+        return uuid.uuid4().hex
+
+    def add_message(self, session_id: str, role: str, content: str):
+        with self.session_factory() as s:
+            msg = Message(session_id=session_id, role=role, content=content)
+            s.add(msg)
+            s.commit()
+
+    def get_messages(self, session_id: str) -> list[Message]:
+        with self.session_factory() as s:
+            return list(s.query(Message).filter_by(session_id=session_id).order_by(Message.timestamp).all())
+
+    def clear_history(self, session_id: str):
+        with self.session_factory() as s:
+            s.query(Message).filter_by(session_id=session_id).delete()
+            s.commit()

--- a/langgraph-sql-agent/chat/models.py
+++ b/langgraph-sql-agent/chat/models.py
@@ -1,0 +1,17 @@
+from datetime import datetime
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+from sqlalchemy import String, Text, DateTime
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class Message(Base):
+    __tablename__ = "messages"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    session_id: Mapped[str] = mapped_column(String(64), index=True)
+    role: Mapped[str] = mapped_column(String(16))
+    content: Mapped[str] = mapped_column(Text())
+    timestamp: Mapped[datetime] = mapped_column(DateTime(), default=datetime.utcnow)

--- a/langgraph-sql-agent/config/config.yaml
+++ b/langgraph-sql-agent/config/config.yaml
@@ -1,13 +1,20 @@
-vector:
-  type: qdrant
-  url: "http://localhost:6333"
+embedding:
+  provider: "openai"
+  model_id: "text-embedding-ada-002"
+  api_key: "YOUR_OPENAI_KEY"
+
+llm:
+  provider: "openai"
+  model_id: "gpt-3.5-turbo"
+  api_key: "YOUR_OPENAI_KEY"
+
+vector_db:
+  provider: "qdrant"
+  host: "http://localhost:6333"
   collection: "documents"
 
 sql:
   connection_string: "mysql+pymysql://user:password@localhost:3306/mydb"
 
-embeddings:
-  model: openai
-  api_key: "YOUR_OPENAI_KEY"
-
-
+history:
+  db_uri: "sqlite:///chat_history.db"

--- a/langgraph-sql-agent/main.py
+++ b/langgraph-sql-agent/main.py
@@ -1,18 +1,23 @@
 import argparse
 from agent.graph import build_graph
 from config.config import load_config
+from chat import HistoryManager
 
 
 def main():
     parser = argparse.ArgumentParser(description="LangGraph SQL Agent")
     parser.add_argument("--query", required=True, help="Natural language question")
     parser.add_argument("--debug", action="store_true", help="Return intermediate steps")
+    parser.add_argument("--session-id", help="Existing session ID")
     args = parser.parse_args()
 
     config = load_config()
-    graph = build_graph(config, debug=args.debug)
-    result = graph.invoke({"query": args.query})
-    print(result)
+    history = HistoryManager(config["history"]["db_uri"])
+    session_id = args.session_id or history.create_session_id()
+    history.add_message(session_id, "user", args.query)
+    graph = build_graph(config, session_id=session_id, history_manager=history, debug=args.debug)
+    result = graph.invoke({"query": args.query, "session_id": session_id})
+    print(result.get("answer"))
 
 
 if __name__ == "__main__":

--- a/langgraph-sql-agent/providers/__init__.py
+++ b/langgraph-sql-agent/providers/__init__.py
@@ -1,0 +1,4 @@
+from .embeddings import get_embedding_provider
+from .llms import get_llm_provider
+
+__all__ = ["get_embedding_provider", "get_llm_provider"]

--- a/langgraph-sql-agent/providers/embeddings/__init__.py
+++ b/langgraph-sql-agent/providers/embeddings/__init__.py
@@ -1,0 +1,3 @@
+from .factory import get_embedding_provider
+
+__all__ = ["get_embedding_provider"]

--- a/langgraph-sql-agent/providers/embeddings/base.py
+++ b/langgraph-sql-agent/providers/embeddings/base.py
@@ -1,0 +1,10 @@
+from abc import ABC, abstractmethod
+from typing import List
+
+
+class EmbeddingProvider(ABC):
+    """Abstract base class for embedding providers."""
+
+    @abstractmethod
+    def embed(self, text: str) -> List[float]:
+        raise NotImplementedError

--- a/langgraph-sql-agent/providers/embeddings/bedrock.py
+++ b/langgraph-sql-agent/providers/embeddings/bedrock.py
@@ -1,0 +1,13 @@
+from typing import List
+
+from langchain.embeddings import BedrockEmbeddings
+
+from .base import EmbeddingProvider
+
+
+class BedrockEmbeddingProvider(EmbeddingProvider):
+    def __init__(self, model_id: str, region: str | None = None):
+        self.embeddings = BedrockEmbeddings(model_id=model_id, region_name=region)
+
+    def embed(self, text: str) -> List[float]:
+        return self.embeddings.embed_query(text)

--- a/langgraph-sql-agent/providers/embeddings/factory.py
+++ b/langgraph-sql-agent/providers/embeddings/factory.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from .openai import OpenAIEmbeddingProvider
+from .bedrock import BedrockEmbeddingProvider
+from .huggingface import HuggingFaceEmbeddingProvider
+from .ollama import OllamaEmbeddingProvider
+
+
+def get_embedding_provider(cfg: dict):
+    provider = cfg.get("provider", "openai")
+    model_id = cfg.get("model_id")
+    if provider == "openai":
+        return OpenAIEmbeddingProvider(api_key=cfg.get("api_key"))
+    if provider == "bedrock":
+        return BedrockEmbeddingProvider(model_id=model_id, region=cfg.get("region"))
+    if provider == "huggingface":
+        return HuggingFaceEmbeddingProvider(model_id=model_id)
+    if provider == "ollama":
+        return OllamaEmbeddingProvider(model_id=model_id)
+    raise ValueError(f"Unknown embedding provider: {provider}")

--- a/langgraph-sql-agent/providers/embeddings/huggingface.py
+++ b/langgraph-sql-agent/providers/embeddings/huggingface.py
@@ -1,0 +1,12 @@
+from typing import List
+from langchain.embeddings import HuggingFaceEmbeddings
+
+from .base import EmbeddingProvider
+
+
+class HuggingFaceEmbeddingProvider(EmbeddingProvider):
+    def __init__(self, model_id: str):
+        self.embeddings = HuggingFaceEmbeddings(model_name=model_id)
+
+    def embed(self, text: str) -> List[float]:
+        return self.embeddings.embed_query(text)

--- a/langgraph-sql-agent/providers/embeddings/ollama.py
+++ b/langgraph-sql-agent/providers/embeddings/ollama.py
@@ -1,0 +1,12 @@
+from typing import List
+from langchain.embeddings import OllamaEmbeddings
+
+from .base import EmbeddingProvider
+
+
+class OllamaEmbeddingProvider(EmbeddingProvider):
+    def __init__(self, model_id: str = "nomic-embed-text"):
+        self.embeddings = OllamaEmbeddings(model=model_id)
+
+    def embed(self, text: str) -> List[float]:
+        return self.embeddings.embed_query(text)

--- a/langgraph-sql-agent/providers/embeddings/openai.py
+++ b/langgraph-sql-agent/providers/embeddings/openai.py
@@ -1,0 +1,12 @@
+from typing import List
+from langchain.embeddings import OpenAIEmbeddings
+
+from .base import EmbeddingProvider
+
+
+class OpenAIEmbeddingProvider(EmbeddingProvider):
+    def __init__(self, api_key: str | None = None):
+        self.embeddings = OpenAIEmbeddings(openai_api_key=api_key)
+
+    def embed(self, text: str) -> List[float]:
+        return self.embeddings.embed_query(text)

--- a/langgraph-sql-agent/providers/llms/__init__.py
+++ b/langgraph-sql-agent/providers/llms/__init__.py
@@ -1,0 +1,3 @@
+from .factory import get_llm_provider
+
+__all__ = ["get_llm_provider"]

--- a/langgraph-sql-agent/providers/llms/base.py
+++ b/langgraph-sql-agent/providers/llms/base.py
@@ -1,0 +1,9 @@
+from abc import ABC, abstractmethod
+
+
+class LLMProvider(ABC):
+    """Abstract base class for language models."""
+
+    @abstractmethod
+    def __call__(self, prompt: str) -> str:
+        raise NotImplementedError

--- a/langgraph-sql-agent/providers/llms/bedrock.py
+++ b/langgraph-sql-agent/providers/llms/bedrock.py
@@ -1,0 +1,11 @@
+from langchain.llms.bedrock import Bedrock
+
+from .base import LLMProvider
+
+
+class BedrockLLMProvider(LLMProvider):
+    def __init__(self, model_id: str, region: str | None = None):
+        self.llm = Bedrock(model_id=model_id, region_name=region)
+
+    def __call__(self, prompt: str) -> str:
+        return self.llm(prompt)

--- a/langgraph-sql-agent/providers/llms/factory.py
+++ b/langgraph-sql-agent/providers/llms/factory.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from .openai import OpenAILLMProvider
+from .bedrock import BedrockLLMProvider
+from .huggingface import HuggingFaceLLMProvider
+from .ollama import OllamaLLMProvider
+
+
+def get_llm_provider(cfg: dict):
+    provider = cfg.get("provider", "openai")
+    model_id = cfg.get("model_id")
+    if provider == "openai":
+        return OpenAILLMProvider(model_id=model_id, api_key=cfg.get("api_key"))
+    if provider == "bedrock":
+        return BedrockLLMProvider(model_id=model_id, region=cfg.get("region"))
+    if provider == "huggingface":
+        return HuggingFaceLLMProvider(model_id=model_id, api_token=cfg.get("api_token"))
+    if provider == "ollama":
+        return OllamaLLMProvider(model_id=model_id)
+    raise ValueError(f"Unknown LLM provider: {provider}")

--- a/langgraph-sql-agent/providers/llms/huggingface.py
+++ b/langgraph-sql-agent/providers/llms/huggingface.py
@@ -1,0 +1,11 @@
+from langchain.llms import HuggingFaceHub
+
+from .base import LLMProvider
+
+
+class HuggingFaceLLMProvider(LLMProvider):
+    def __init__(self, model_id: str, api_token: str | None = None):
+        self.llm = HuggingFaceHub(repo_id=model_id, huggingfacehub_api_token=api_token)
+
+    def __call__(self, prompt: str) -> str:
+        return self.llm(prompt)

--- a/langgraph-sql-agent/providers/llms/ollama.py
+++ b/langgraph-sql-agent/providers/llms/ollama.py
@@ -1,0 +1,11 @@
+from langchain.llms import Ollama
+
+from .base import LLMProvider
+
+
+class OllamaLLMProvider(LLMProvider):
+    def __init__(self, model_id: str):
+        self.llm = Ollama(model=model_id)
+
+    def __call__(self, prompt: str) -> str:
+        return self.llm(prompt)

--- a/langgraph-sql-agent/providers/llms/openai.py
+++ b/langgraph-sql-agent/providers/llms/openai.py
@@ -1,0 +1,11 @@
+from langchain.llms import OpenAI
+
+from .base import LLMProvider
+
+
+class OpenAILLMProvider(LLMProvider):
+    def __init__(self, model_id: str, api_key: str | None = None):
+        self.llm = OpenAI(model_name=model_id, openai_api_key=api_key)
+
+    def __call__(self, prompt: str) -> str:
+        return self.llm(prompt)

--- a/langgraph-sql-agent/requirements.txt
+++ b/langgraph-sql-agent/requirements.txt
@@ -4,3 +4,5 @@ qdrant-client>=1.6.0
 SQLAlchemy>=2.0
 PyMySQL>=1.0
 PyYAML>=6.0
+streamlit>=1.25
+psycopg2-binary>=2.9

--- a/langgraph-sql-agent/ui/app.py
+++ b/langgraph-sql-agent/ui/app.py
@@ -1,0 +1,29 @@
+import streamlit as st
+from agent.graph import build_graph
+from config.config import load_config
+from chat.history_manager import HistoryManager
+
+cfg = load_config()
+manager = HistoryManager(cfg["history"]["db_uri"])
+
+if "session_id" not in st.session_state:
+    st.session_state.session_id = manager.create_session_id()
+
+st.sidebar.header("Configuration")
+st.sidebar.write(cfg)
+
+st.title("LangGraph SQL Agent")
+
+history = manager.get_messages(st.session_state.session_id)
+for msg in history:
+    st.chat_message(msg.role).write(msg.content)
+
+if prompt := st.chat_input("Ask a question"):
+    st.chat_message("user").write(prompt)
+    manager.add_message(st.session_state.session_id, "user", prompt)
+
+    graph = build_graph(cfg)
+    result = graph.invoke({"query": prompt})
+    answer = result.get("answer")
+    st.chat_message("assistant").write(answer)
+    manager.add_message(st.session_state.session_id, "assistant", str(answer))

--- a/langgraph-sql-agent/vector/qdrant_client.py
+++ b/langgraph-sql-agent/vector/qdrant_client.py
@@ -2,13 +2,16 @@ from typing import List
 from qdrant_client import QdrantClient
 from .base import VectorClient
 
+from providers.embeddings import get_embedding_provider
+
 
 class QdrantVectorClient(VectorClient):
-    def __init__(self, url: str, collection: str):
+    def __init__(self, url: str, collection: str, embedding_cfg: dict | None = None):
         self.client = QdrantClient(url=url)
         self.collection = collection
+        self.embedding = get_embedding_provider(embedding_cfg or {})
 
     def similarity_search(self, query: str, k: int = 5) -> List[str]:
-        # Here we assume embeddings already exist in Qdrant
-        results = self.client.search(collection_name=self.collection, query_text=query, top=k)
+        vector = self.embedding.embed(query)
+        results = self.client.search(collection_name=self.collection, query_vector=vector, top=k)
         return [hit.payload.get("text", "") for hit in results]


### PR DESCRIPTION
## Summary
- add provider abstractions for embeddings and LLMs
- implement chat history persistence with SQLAlchemy
- build Streamlit UI for conversations
- update agent graph with history node and provider usage
- expand configuration and update README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684997f646048325aa2e9d2b5ac48825