### PR TITLE
Add API endpoint for natural language SQL queries

### DIFF
--- a/langgraph-sql-agent/README.md
+++ b/langgraph-sql-agent/README.md
@@ -23,4 +23,10 @@ python main.py --query "Your question here"
 streamlit run ui/app.py
 ```
 
+5. Start the FastAPI server:
+
+```bash
+uvicorn api.app:app --reload
+```
+
 See `config/config.yaml` for configuration options.

--- a/langgraph-sql-agent/api/app.py
+++ b/langgraph-sql-agent/api/app.py
@@ -1,0 +1,59 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+import time
+
+from agent.graph import build_graph
+from config.config import load_config
+from chat.history_manager import HistoryManager
+
+config = load_config()
+history = HistoryManager(config["history"]["db_uri"])
+
+app = FastAPI(title="LangGraph SQL Agent API")
+
+class QueryRequest(BaseModel):
+    question: str
+    session_id: str | None = None
+
+class QueryResponse(BaseModel):
+    session_id: str
+    sql: str | None = None
+    results: list | None = None
+    context: str | None = None
+    error: str | None = None
+    execution_time: float
+    model: str | None = None
+
+@app.post("/query", response_model=QueryResponse)
+def query(req: QueryRequest) -> QueryResponse:
+    session_id = req.session_id or history.create_session_id()
+    history.add_message(session_id, "user", req.question)
+
+    graph = build_graph(config, session_id=session_id, history_manager=history, debug=True)
+
+    start = time.perf_counter()
+    try:
+        result = graph.invoke({"query": req.question})
+        error = result.get("error")
+        sql = result.get("sql")
+        results = result.get("results")
+        context = result.get("context")
+    except Exception as e:
+        result = {}
+        error = str(e)
+        sql = None
+        results = None
+        context = None
+    execution_time = time.perf_counter() - start
+
+    history.add_message(session_id, "assistant", str(result.get("answer")))
+
+    return QueryResponse(
+        session_id=session_id,
+        sql=sql,
+        results=results,
+        context=context,
+        error=error,
+        execution_time=execution_time,
+        model=config.get("llm", {}).get("model_id"),
+    )

--- a/langgraph-sql-agent/requirements.txt
+++ b/langgraph-sql-agent/requirements.txt
@@ -6,3 +6,5 @@ PyMySQL>=1.0
 PyYAML>=6.0
 streamlit>=1.25
 psycopg2-binary>=2.9
+fastapi>=0.111.0
+uvicorn>=0.25.0


### PR DESCRIPTION
## Summary
- add FastAPI server to expose `/query` endpoint
- document how to run the API server
- include FastAPI requirements

## Testing
- `python -m py_compile langgraph-sql-agent/api/app.py`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68499a33f51c8325983ce0a80d778f3b